### PR TITLE
Potential fix to stop crashes on unicode strings in Python 2.7

### DIFF
--- a/IndexedRedis/__init__.py
+++ b/IndexedRedis/__init__.py
@@ -22,7 +22,10 @@ except NameError:
 
 if bytes == str:
 	# Python 2, no additional decoding necessary.
-	tostr = str
+	def tostr(x):
+		if isinstance(x, unicode):
+			return x.encode('utf-8')
+		return str(x)
 	decodeDict = lambda x : x
 else:
 	# Python 3, additional decoding necessary


### PR DESCRIPTION
Thanks for making a great library, it's exactly what I'm looking for as a near drop in replacement for `peewee` on a project I'm working on.  Ran into a problem though on Python 2.7 using unicode strings so I implemented this fix.  I've tested it on my own project which is storing then filtering on a field that often contains unicode characters over around 6,000 records, and it seems to work well.
